### PR TITLE
[FIX] Cleanup code

### DIFF
--- a/backlog/backlog.go
+++ b/backlog/backlog.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// DefaultBacklogSize это размер backlog по умолчанию
-	DefaultBacklogSize int = 50000000
+	DefaultBacklogSize = 50000000
 )
 
 // Backlog это журнал отставания репликации

--- a/backlog/backlog_test.go
+++ b/backlog/backlog_test.go
@@ -24,15 +24,15 @@ func TestBacklog(t *testing.T) {
 func testBacklogOverflow(t *testing.T) {
 	backlog := New(2)
 	for i := 0; i < 2; i++ {
-		command := command.New([]string{fmt.Sprintf("command_%d", i)})
-		err := backlog.Add(command)
+		cmd := command.New([]string{fmt.Sprintf("command_%d", i)})
+		err := backlog.Add(cmd)
 		if err != nil {
 			t.Fatalf("backlog error: %q", err)
 		}
 	}
 
-	command := command.New([]string{fmt.Sprintf("command_%d", 3)})
-	err := backlog.Add(command)
+	cmd := command.New([]string{fmt.Sprintf("command_%d", 3)})
+	err := backlog.Add(cmd)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -57,9 +57,9 @@ func testBacklog(
 
 	stack := []command.Command{}
 	for i := 0; i < add; i++ {
-		command := command.New([]string{fmt.Sprintf("command_%d", i)})
-		stack = append(stack, command)
-		err := backlog.Add(command)
+		cmd := command.New([]string{fmt.Sprintf("command_%d", i)})
+		stack = append(stack, cmd)
+		err := backlog.Add(cmd)
 		if err != nil {
 			t.Fatalf("backlog error: %v", err)
 		}
@@ -69,9 +69,9 @@ func testBacklog(
 	}
 
 	for i := 0; i < get; i++ {
-		command := backlog.Get()
-		if !reflect.DeepEqual(stack[i], command) {
-			t.Fatalf("expected command %q but actual %q", stack[i], command)
+		cmd := backlog.Get()
+		if !reflect.DeepEqual(stack[i], cmd) {
+			t.Fatalf("expected command %q but actual %q", stack[i], cmd)
 		}
 	}
 	count := backlog.Count()

--- a/backlog/backlog_test.go
+++ b/backlog/backlog_test.go
@@ -55,7 +55,7 @@ func testBacklog(
 	}
 	backlog := New(size)
 
-	stack := []command.Command{}
+	var stack = make([]command.Command, 0, add)
 	for i := 0; i < add; i++ {
 		cmd := command.New([]string{fmt.Sprintf("command_%d", i)})
 		stack = append(stack, cmd)

--- a/data/interface_test.go
+++ b/data/interface_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-// TestInteface проверяет соответствие структур интерфейсам
+// TestInterface проверяет соответствие структур интерфейсам
 func TestInterface(t *testing.T) {
 	t.Run("Key", func(t *testing.T) {
 		t.Run("SortedSet", func(t *testing.T) {

--- a/example/consumer.go
+++ b/example/consumer.go
@@ -104,13 +104,13 @@ func (c *Consumer) Key(key data.Key) error {
 		return nil
 	}
 
-	data := struct {
+	item := struct {
 		keyName string
 	}{
 		keyName: sortedSet.Name(),
 	}
 
-	return c.Send("_PATH_", data)
+	return c.Send("_PATH_", item)
 }
 
 // CheckCommand возвращает true если команда интересна получателю
@@ -200,12 +200,12 @@ func (c *Consumer) Send(url string, data interface{}) error {
 func (c *Consumer) status(port int, status string) {
 	t := time.Now().Local().Unix()
 	n := (port - 6300) * 10
-	data := fmt.Sprintf("migration.status.%d.%s %d %d\n", port, status, n, t)
+	buf := fmt.Sprintf("migration.status.%d.%s %d %d\n", port, status, n, t)
 
 	for {
 		conn, err := net.Dial("tcp", "graphite")
 		if err == nil {
-			_, err := conn.Write([]byte(data))
+			_, err := conn.Write([]byte(buf))
 			_ = conn.Close()
 			if err == nil {
 				break

--- a/rdb/decode.go
+++ b/rdb/decode.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	tokenLevelStart int = iota
+	tokenLevelStart = iota
 	tokenLevelInit
 	tokenLevelDB
 )

--- a/rdb/decode.go
+++ b/rdb/decode.go
@@ -67,7 +67,7 @@ func (d *decoder) DecodeKeys(consumer KeyConsumer) error {
 			if ok {
 				err = nil
 			} else {
-				err = fmt.Errorf(`Unexpected io.EOF, actual token "%#v"`, token)
+				err = fmt.Errorf(`unexpected io.EOF, actual token "%#v"`, token)
 			}
 			return err
 		}
@@ -107,7 +107,7 @@ func (d *decoder) Decode(consumer Consumer) error {
 			if ok {
 				err = consumer.SetEOF(eof)
 			} else {
-				err = fmt.Errorf(`Unexpected io.EOF, actual token "%#v"`, token)
+				err = fmt.Errorf(`unexpected io.EOF, actual token "%#v"`, token)
 			}
 			return err
 		}

--- a/rdb/reader.go
+++ b/rdb/reader.go
@@ -210,7 +210,7 @@ func (r *reader) ReadLength() (length uint32, encoding int8, err error) {
 		encoding = int8(prefix & 0x3F)
 		return 0, encoding, nil
 	}
-	return 0, 0, fmt.Errorf("Undefined length")
+	return 0, 0, fmt.Errorf("undefined length")
 }
 
 // ReadUint8 читает один байт


### PR DESCRIPTION
- variable name collides with imported package name
- prealloc
- omit type
- typo
- errors, must start in lowercase (see https://github.com/golang/go/wiki/Errors)